### PR TITLE
chore: set min required terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module creates:
 
 ## Prerequisites
 
-- Terraform >= 1.0
+- Terraform >= 1.9.0
 - AWS CLI configured with appropriate permissions
 - Existing VPC with at least 2 private subnets
 - S3 bucket for storing telemetry data

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module creates:
 
 ```hcl
 module "otel_collector" {
-  source = "monte-carlo-data/terraform-aws-otel-collector"
+  source = "monte-carlo-data/otel-collector/aws"
 
   deployment_name           = "my-otel-collector"
   existing_vpc_id           = "vpc-12345678"
@@ -37,7 +37,7 @@ module "otel_collector" {
 
 ```hcl
 module "otel_collector" {
-  source = "monte-carlo-data/terraform-aws-otel-collector"
+  source = "monte-carlo-data/otel-collector/aws"
 
   # Required variables
   deployment_name           = "production-otel-collector"

--- a/variables.tf
+++ b/variables.tf
@@ -56,11 +56,8 @@ variable "http_port" {
     condition     = var.http_port >= 1024 && var.http_port <= 65535
     error_message = "Port must be between 1024 and 65535."
   }
-}
-
-check "port_validation" {
-  assert {
-    condition     = var.grpc_port != var.http_port
+  validation {
+    condition     = var.http_port != var.grpc_port
     error_message = "HTTP port must be different from gRPC port to avoid conflicts."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,11 @@ variable "http_port" {
     condition     = var.http_port >= 1024 && var.http_port <= 65535
     error_message = "Port must be between 1024 and 65535."
   }
-  validation {
-    condition     = var.http_port != var.grpc_port
+}
+
+check "port_validation" {
+  assert {
+    condition     = var.grpc_port != var.http_port
     error_message = "HTTP port must be different from gRPC port to avoid conflicts."
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Set min required Terraform version to 1.9.0 because we depend on the enhanced variable validation features: [docs](https://www.hashicorp.com/en/blog/terraform-1-9-enhances-input-variable-validations)