### PR TITLE
feat(athena): opt-in partition projection for the traces Glue table (AI-634)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,40 @@ module "otel_collector" {
 }
 ```
 
+### Athena Partition Projection (recommended with `deploy_athena_resources`)
+
+The collector writes telemetry as one S3 object per batch under minute-grained,
+Hive-style paths (`.../traces/<service.name>/year=YYYY/month=MM/day=DD/hour=HH/minute=MM/`),
+and the Glue crawler registers each minute as a catalog partition. As data accumulates,
+Athena's partition enumeration becomes the dominant cost of multi-day queries. Enabling
+[partition projection](https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html)
+declares the `traces` table in Terraform with projection parameters so Athena computes
+partition locations instead of enumerating the catalog:
+
+```hcl
+module "otel_collector" {
+  source = "monte-carlo-data/otel-collector/aws"
+
+  # ... basic + athena configuration ...
+  deploy_athena_resources = true
+
+  enable_partition_projection = true
+  telemetry_service_names     = ["my-agent"] # the service.name values your agents emit
+  projection_year_range       = "2025,2032"  # keep tight; widen as needed
+}
+```
+
+Notes:
+
+- **Existing deployments:** the crawler has already created the `traces` table, so import it
+  before applying: `terraform import 'module.otel_collector.module.athena_resources[0].aws_glue_catalog_table.traces[0]' <account-id>:<deployment_name>-telemetry-db:traces`
+  (adjust the module path to your configuration). Applying without the import fails with
+  `AlreadyExistsException`.
+- Queries must keep filtering on the partition columns (`year`, `month`, ...) to benefit;
+  unfiltered full-table scans still enumerate the whole projected range.
+- The crawler keeps running for schema evolution; with projection enabled Athena no longer
+  reads the catalog partitions it registers.
+
 ## Migration Notes
 
 This release refactors resources into submodules. To avoid resource recreation for existing users, the module includes `moved` blocks that map old resource addresses to their new module addresses. Run `terraform apply` as usual and Terraform will migrate state automatically.
@@ -125,7 +159,9 @@ If you cannot use `moved` blocks (older Terraform versions), you will need to pe
 | <a name="input_batch_size"></a> [batch\_size](#input\_batch\_size) | Batch size for sending telemetry data | `number` | `1024` | no |
 | <a name="input_batch_timeout"></a> [batch\_timeout](#input\_batch\_timeout) | Timeout for batch processor in seconds | `string` | `"10s"` | no |
 | <a name="input_container_image"></a> [container\_image](#input\_container\_image) | OpenTelemetry Collector container image | `string` | `"otel/opentelemetry-collector-contrib:latest"` | no |
+| <a name="input_deploy_athena_resources"></a> [deploy\_athena\_resources](#input\_deploy\_athena\_resources) | Whether to deploy AWS Glue resources for Athena (Glue classifier, SQS queue, IAM role, and Glue crawler) | `bool` | `false` | no |
 | <a name="input_deploy_otel_collector"></a> [deploy\_otel\_collector](#input\_deploy\_otel\_collector) | Whether to deploy the OpenTelemetry Collector infrastructure (ECS, NLB, IAM, etc.) | `bool` | `true` | no |
+| <a name="input_enable_partition_projection"></a> [enable\_partition\_projection](#input\_enable\_partition\_projection) | Declare the traces Glue table with Athena partition projection enabled (recommended). Requires `telemetry_service_names`. Only relevant when `deploy_athena_resources` is true. | `bool` | `false` | no |
 | <a name="input_existing_security_group_id"></a> [existing\_security\_group\_id](#input\_existing\_security\_group\_id) | Optional additional security group ID to attach to the OpenTelemetry Collector resources. | `string` | `"N/A"` | no |
 | <a name="input_external_access_principal"></a> [external\_access\_principal](#input\_external\_access\_principal) | Principal (AWS ARN/account ID or Federated identifier) allowed to assume the external access role. | `string` | `"N/A"` | no |
 | <a name="input_external_access_principal_type"></a> [external\_access\_principal\_type](#input\_external\_access\_principal\_type) | Type of principal for external access role | `string` | `"AWS"` | no |
@@ -136,9 +172,12 @@ If you cannot use `moved` blocks (older Terraform versions), you will need to pe
 | <a name="input_mcd_otel_collector_task_role_arn"></a> [mcd\_otel\_collector\_task\_role\_arn](#input\_mcd\_otel\_collector\_task\_role\_arn) | ARN of the role that should be granted write access to the telemetry S3 bucket. | `string` | `""` | no |
 | <a name="input_memory_limit_mib"></a> [memory\_limit\_mib](#input\_memory\_limit\_mib) | Memory limit for the collector in MiB | `number` | `1500` | no |
 | <a name="input_memory_spike_limit_mib"></a> [memory\_spike\_limit\_mib](#input\_memory\_spike\_limit\_mib) | Memory spike limit for the collector in MiB | `number` | `512` | no |
+| <a name="input_projection_year_range"></a> [projection\_year\_range](#input\_projection\_year\_range) | Inclusive year range for Athena partition projection, as `"min,max"` (e.g. `"2025,2032"`). Keep the range tight. | `string` | `"2025,2032"` | no |
 | <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | CPU units for the task (1024 = 1 vCPU) | `number` | `1024` | no |
 | <a name="input_task_desired_count"></a> [task\_desired\_count](#input\_task\_desired\_count) | Desired number of running tasks for the OpenTelemetry Collector service | `number` | `2` | no |
 | <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | Memory for the task in MB | `number` | `2048` | no |
+| <a name="input_telemetry_data_bucket_notification_sns_topic_arn"></a> [telemetry\_data\_bucket\_notification\_sns\_topic\_arn](#input\_telemetry\_data\_bucket\_notification\_sns\_topic\_arn) | Optional ARN of the SNS topic to subscribe the SQS queue to for triggering the Glue crawler. If not provided, a SNS topic will be created. | `string` | `""` | no |
+| <a name="input_telemetry_service_names"></a> [telemetry\_service\_names](#input\_telemetry\_service\_names) | OpenTelemetry `service.name` values your agents emit. Required when `enable_partition_projection` is true. | `list(string)` | `[]` | no |
 | <a name="input_vpc_endpoint_id"></a> [vpc\_endpoint\_id](#input\_vpc\_endpoint\_id) | Optional VPC endpoint ID to restrict S3 writes to that endpoint. | `string` | `""` | no |
 
 ## Outputs

--- a/examples/athena/main.tf
+++ b/examples/athena/main.tf
@@ -28,6 +28,15 @@ module "otel_collector" {
   # Optional: Provide an existing SNS topic ARN. If omitted (empty string), the module will create one automatically
   telemetry_data_bucket_notification_sns_topic_arn = var.telemetry_data_bucket_notification_sns_topic_arn
 
+  # Recommended: enable Athena partition projection on the traces table so multi-day
+  # queries stay fast as minute-grained partitions accumulate. List the service.name
+  # values your agents emit, e.g.:
+  #   enable_partition_projection = true
+  #   telemetry_service_names     = ["my-agent"]
+  enable_partition_projection = var.enable_partition_projection
+  telemetry_service_names     = var.telemetry_service_names
+  projection_year_range       = var.projection_year_range
+
   # Optional customizations
   task_desired_count = var.task_desired_count
   task_cpu           = var.task_cpu

--- a/examples/athena/variables.tf
+++ b/examples/athena/variables.tf
@@ -55,3 +55,21 @@ variable "task_memory" {
   default     = 2048
 }
 
+variable "enable_partition_projection" {
+  description = "Declare the traces Glue table with Athena partition projection enabled (recommended). Requires telemetry_service_names."
+  type        = bool
+  default     = false
+}
+
+variable "telemetry_service_names" {
+  description = "OpenTelemetry service.name values your agents emit. Required when enable_partition_projection is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "projection_year_range" {
+  description = "Inclusive year range for Athena partition projection, as \"min,max\"."
+  type        = string
+  default     = "2025,2032"
+}
+

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,13 @@ module "athena_resources" {
   source = "./modules/athena-resources"
   count  = var.deploy_athena_resources ? 1 : 0
 
-  deployment_name           = var.deployment_name
-  common_tags               = local.common_tags
-  sns_topic_arn             = var.telemetry_data_bucket_notification_sns_topic_arn
-  telemetry_data_bucket_arn = local.telemetry_bucket_arn
+  deployment_name             = var.deployment_name
+  common_tags                 = local.common_tags
+  sns_topic_arn               = var.telemetry_data_bucket_notification_sns_topic_arn
+  telemetry_data_bucket_arn   = local.telemetry_bucket_arn
+  enable_partition_projection = var.enable_partition_projection
+  telemetry_service_names     = var.telemetry_service_names
+  projection_year_range       = var.projection_year_range
 }
 
 

--- a/modules/athena-resources/main.tf
+++ b/modules/athena-resources/main.tf
@@ -213,6 +213,113 @@ resource "aws_glue_catalog_database" "telemetry_database" {
   tags = var.common_tags
 }
 
+# Glue Table for traces (declared only when partition projection is enabled).
+#
+# Without this resource the crawler creates and owns the table, and Athena enumerates
+# every crawler-registered partition (one per minute of telemetry) when planning a
+# query — enumeration cost grows unboundedly with data age. Declaring the table lets
+# us attach Athena partition-projection parameters so partition locations are computed
+# from the ranges below instead. The crawler still runs against the same table: its
+# Tables.AddOrUpdateBehavior=MergeNewColumns update path only adds columns and never
+# removes table parameters, so projection settings and the crawler coexist.
+resource "aws_glue_catalog_table" "traces" {
+  count = var.enable_partition_projection ? 1 : 0
+
+  name          = "traces"
+  database_name = aws_glue_catalog_database.telemetry_database.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    classification = "traces"
+
+    "projection.enabled" = "true"
+    # The collector writes traces under a bare <service.name> path segment; the
+    # crawler surfaces it as the leading string partition column partition_0.
+    "projection.partition_0.type"   = "enum"
+    "projection.partition_0.values" = join(",", var.telemetry_service_names)
+    "projection.year.type"          = "integer"
+    "projection.year.range"         = var.projection_year_range
+    "projection.month.type"         = "integer"
+    "projection.month.range"        = "1,12"
+    "projection.month.digits"       = "2"
+    "projection.day.type"           = "integer"
+    "projection.day.range"          = "1,31"
+    "projection.day.digits"         = "2"
+    "projection.hour.type"          = "integer"
+    "projection.hour.range"         = "0,23"
+    "projection.hour.digits"        = "2"
+    "projection.minute.type"        = "integer"
+    "projection.minute.range"       = "0,59"
+    "projection.minute.digits"      = "2"
+    # $${...} renders literal ${...} — Athena substitutes these, not Terraform.
+    "storage.location.template" = "${local.s3_traces_path}$${partition_0}/year=$${year}/month=$${month}/day=$${day}/hour=$${hour}/minute=$${minute}"
+  }
+
+  storage_descriptor {
+    location      = local.s3_traces_path
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "com.amazonaws.glue.serde.GrokSerDe"
+      parameters = {
+        "input.format" = local.grok_pattern
+      }
+    }
+
+    columns {
+      name = "value"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "partition_0" # service.name path segment
+    type = "string"
+  }
+  partition_keys {
+    name = "year"
+    type = "string"
+  }
+  partition_keys {
+    name = "month"
+    type = "string"
+  }
+  partition_keys {
+    name = "day"
+    type = "string"
+  }
+  partition_keys {
+    name = "hour"
+    type = "string"
+  }
+  partition_keys {
+    name = "minute"
+    type = "string"
+  }
+
+  lifecycle {
+    # The crawler keeps updating table statistics on every run and may add columns
+    # via MergeNewColumns; don't fight it on plan. Projection parameters stay
+    # Terraform-managed.
+    ignore_changes = [
+      storage_descriptor[0].columns,
+      parameters["averageRecordSize"],
+      parameters["compressionType"],
+      parameters["CrawlerSchemaDeserializerVersion"],
+      parameters["CrawlerSchemaSerializerVersion"],
+      parameters["CRAWL_RUN_ID"],
+      parameters["grokPattern"],
+      parameters["objectCount"],
+      parameters["partition_filtering.enabled"],
+      parameters["recordCount"],
+      parameters["sizeKey"],
+      parameters["typeOfData"],
+      parameters["UPDATED_BY_CRAWLER"],
+    ]
+  }
+}
+
 # Glue Crawler
 resource "aws_glue_crawler" "telemetry_crawler" {
   name          = "${var.deployment_name}-telemetry-crawler"
@@ -239,6 +346,9 @@ resource "aws_glue_crawler" "telemetry_crawler" {
   configuration = jsonencode({
     Version = 1.0
     CrawlerOutput = {
+      Partitions = {
+        AddOrUpdateBehavior = "InheritFromTable"
+      }
       Tables = {
         AddOrUpdateBehavior = "MergeNewColumns",
         TableThreshold      = 1
@@ -250,6 +360,10 @@ resource "aws_glue_crawler" "telemetry_crawler" {
   })
 
   tags = var.common_tags
+
+  # When the traces table is declared (partition projection), it must exist before
+  # the first crawl so the crawler takes its update path instead of creating the table.
+  depends_on = [aws_glue_catalog_table.traces]
 }
 
 # Lambda UDF Resources

--- a/modules/athena-resources/variables.tf
+++ b/modules/athena-resources/variables.tf
@@ -39,4 +39,32 @@ variable "lambda_udf_memory_size" {
   default     = 1024
 }
 
+variable "enable_partition_projection" {
+  description = "Declare the traces Glue table with Athena partition projection enabled. Athena then computes partition locations from the projection ranges instead of enumerating the Glue catalog, keeping multi-day queries fast as minute-grained partitions accumulate. Requires telemetry_service_names."
+  type        = bool
+  default     = false
+}
+
+variable "telemetry_service_names" {
+  description = "OpenTelemetry service.name values your agents emit (the collector writes each service's traces under its own S3 path segment). Used as the enum values for the service partition projection; required when enable_partition_projection is true."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = !var.enable_partition_projection || length(var.telemetry_service_names) > 0
+    error_message = "telemetry_service_names must list at least one service.name value when enable_partition_projection is true."
+  }
+}
+
+variable "projection_year_range" {
+  description = "Inclusive year range for Athena partition projection, as \"min,max\" (e.g. \"2025,2032\"). Keep the range tight: every extra year adds ~526k virtual partitions to the unpruned enumeration space."
+  type        = string
+  default     = "2025,2032"
+
+  validation {
+    condition     = can(regex("^[0-9]{4},[0-9]{4}$", var.projection_year_range))
+    error_message = "projection_year_range must be two 4-digit years separated by a comma, e.g. \"2025,2032\"."
+  }
+}
+
 

--- a/modules/otel-collector/main.tf
+++ b/modules/otel-collector/main.tf
@@ -258,6 +258,10 @@ exporters:
       s3_bucket: ${local.external_s3_bucket_name}
       s3_base_prefix: mcd/otel-collector/traces
       file_prefix: traces
+      # Pin the exporter default: downstream Glue/Athena resources (partition
+      # projection) depend on this exact layout, so don't let it drift with
+      # collector upgrades.
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
     resource_attrs_to_s3:
       s3_prefix: "service.name"
   awss3/metrics:
@@ -266,6 +270,7 @@ exporters:
       s3_bucket: ${local.external_s3_bucket_name}
       s3_base_prefix: mcd/otel-collector/metrics
       file_prefix: metrics
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
     resource_attrs_to_s3:
       s3_prefix: "service.name"
   awss3/logs:
@@ -274,6 +279,7 @@ exporters:
       s3_bucket: ${local.external_s3_bucket_name}
       s3_base_prefix: mcd/otel-collector/logs
       file_prefix: logs
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
     resource_attrs_to_s3:
       s3_prefix: "service.name"
 

--- a/variables.tf
+++ b/variables.tf
@@ -198,3 +198,21 @@ variable "telemetry_data_bucket_notification_sns_topic_arn" {
   type        = string
   default     = ""
 }
+
+variable "enable_partition_projection" {
+  description = "Declare the traces Glue table with Athena partition projection enabled (recommended). Athena then computes partition locations from the projection ranges instead of enumerating the Glue catalog, keeping multi-day queries fast as minute-grained partitions accumulate. Requires telemetry_service_names. Only relevant when deploy_athena_resources is true."
+  type        = bool
+  default     = false
+}
+
+variable "telemetry_service_names" {
+  description = "OpenTelemetry service.name values your agents emit (the collector writes each service's traces under its own S3 path segment). Required when enable_partition_projection is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "projection_year_range" {
+  description = "Inclusive year range for Athena partition projection, as \"min,max\" (e.g. \"2025,2032\"). Keep the range tight: every extra year adds ~526k virtual partitions to the unpruned enumeration space."
+  type        = string
+  default     = "2025,2032"
+}


### PR DESCRIPTION
## What

Opt-in **Athena partition projection** for the traces table, plus a layout pin for the awss3 exporter.

- `modules/athena-resources`: new `aws_glue_catalog_table "traces"` (created only when `enable_partition_projection = true`) matching the crawler-created shape (GrokSerDe `%{GREEDYDATA:value}`, single `value` column, `partition_0` + `year/month/day/hour/minute` string partition keys) with `projection.*` parameters; new variables `enable_partition_projection`, `telemetry_service_names`, `projection_year_range` (validated).
- Crawler `Configuration` gains `CrawlerOutput.Partitions.AddOrUpdateBehavior = InheritFromTable` (new partitions inherit table-level properties) and `depends_on` the declared table so the first crawl takes the update path.
- `modules/otel-collector`: pins `s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'` on the three awss3 exporters — this is the exporter's current built-in default, made explicit because the projection template (and any downstream ETL) depends on the exact layout and the container image tag floats on `latest`.
- `examples/athena` + README: new variables documented, including the `terraform import` step existing deployments need (their `traces` table is crawler-owned).

## Why

Each collector batch lands as a tiny S3 object under a minute-grained Hive path, and the crawler registers every minute as a Glue partition. After months of telemetry, **Athena partition enumeration becomes the dominant query cost**: on Monte Carlo's own demo deployment (~months of data), any query spanning more than ~1 day — including a bare `SELECT COUNT(*)` — exceeds a 29s API-gateway ceiling and dies with HTTP 502 ([AI-634](https://linear.app/montecarloai/issue/AI-634/demo-athena-otel-trace-table-minute-grained-partitioning-makes-multi)). With projection enabled, Athena computes partition locations from the configured ranges and never reads the catalog partitions, so query planning cost stays flat as data ages.

Kept **opt-in** (default `false`) so existing users see zero behavior change; the crawler keeps running for schema evolution either way (`MergeNewColumns` never removes the manually-set projection parameters — verified against a live crawler-managed deployment).

## Design questions for maintainers

1. **Service segment projection type:** the `<service.name>` path level (`partition_0`) is projected as an `enum` from a required `telemetry_service_names` variable. The alternative (`injected`) needs no list but breaks any query that doesn't filter on `partition_0` — Monte Carlo's agent-observability queries don't, so `enum` seemed right. OK?
2. **Opt-in vs default-on:** happy to flip the default in a follow-up/major if you'd rather new deployments get projection out of the box.
3. Related hardening you may want as follow-ups: pinning the collector `container_image` (currently `latest`, which is what makes the layout pin necessary), and the Terraform data-store module creates the bucket with **no lifecycle rules** while the CloudFormation twin expires `mcd/otel-collector/` after 30 days — the divergence affects how wide `projection_year_range` needs to be.

## Verification

- `terraform fmt -recursive -check` clean; `terraform init -backend=false && terraform validate` pass on the root module and `examples/athena` (Terraform 1.9).
- Projection parameter set mirrors the change being applied to the Monte Carlo demo deployment's table for AI-634 (same table shape, captured from a live crawler-created table).

A matching change for the CloudFormation twin (`mcd-public-resources/templates/cloudformation/aws_otel_collector_athena.yaml`) is being opened alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
