### PR TITLE
fix: grant same-account lambda:InvokeFunction on Athena UDF

### DIFF
--- a/modules/athena-resources/main.tf
+++ b/modules/athena-resources/main.tf
@@ -324,16 +324,31 @@ resource "aws_lambda_function" "athena_udf" {
   tags = var.common_tags
 }
 
-# Allow any IAM principal in the same account to invoke the Lambda UDF.
-# Athena executes USING EXTERNAL FUNCTION calls using the caller's IAM credentials
-# (the Monte Carlo Athena integration role). Granting the account root here means
-# any same-account principal that Athena acts on behalf of can invoke the UDF
-# without requiring a separate identity-based lambda:InvokeFunction policy on each
-# individual role — matching the behaviour customers get from the aws-athena-configuration
-# IAM policy snippet in the MC docs.
-resource "aws_lambda_permission" "allow_same_account_invoke" {
-  statement_id  = "AllowSameAccountInvoke"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.athena_udf.function_name
-  principal     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+# Grant each Athena execution role (e.g. the MC integration role) permission to
+# invoke the Lambda UDF via an identity-based policy.
+#
+# For same-account Lambda calls, AWS evaluates BOTH the resource-based policy and
+# the caller's identity-based policy. The account-root resource policy alone is not
+# sufficient — the calling IAM role must also have lambda:InvokeFunction in its own
+# identity policy (confirmed via Athena ErrorType 1500 in prod).
+#
+# Pass the MC Athena integration role name(s) via var.athena_execution_role_names
+# so the module wires the permission automatically.
+resource "aws_iam_role_policy" "athena_execution_role_udf_invoke" {
+  for_each = toset(var.athena_execution_role_names)
+
+  name = "${var.deployment_name}-bedrock-udf-invoke"
+  role = each.value
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowBedrockUDFInvoke"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = aws_lambda_function.athena_udf.arn
+      }
+    ]
+  })
 }

--- a/modules/athena-resources/main.tf
+++ b/modules/athena-resources/main.tf
@@ -10,6 +10,8 @@ locals {
   sns_topic_arn    = local.use_existing_sns ? var.sns_topic_arn : aws_sns_topic.telemetry_notifications[0].arn
 }
 
+data "aws_caller_identity" "current" {}
+
 # Glue Classifier
 resource "aws_glue_classifier" "grok_classifier" {
   name = "${var.deployment_name}-grok-classifier"
@@ -322,3 +324,16 @@ resource "aws_lambda_function" "athena_udf" {
   tags = var.common_tags
 }
 
+# Allow any IAM principal in the same account to invoke the Lambda UDF.
+# Athena executes USING EXTERNAL FUNCTION calls using the caller's IAM credentials
+# (the Monte Carlo Athena integration role). Granting the account root here means
+# any same-account principal that Athena acts on behalf of can invoke the UDF
+# without requiring a separate identity-based lambda:InvokeFunction policy on each
+# individual role — matching the behaviour customers get from the aws-athena-configuration
+# IAM policy snippet in the MC docs.
+resource "aws_lambda_permission" "allow_same_account_invoke" {
+  statement_id  = "AllowSameAccountInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.athena_udf.function_name
+  principal     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+}

--- a/modules/athena-resources/variables.tf
+++ b/modules/athena-resources/variables.tf
@@ -11,7 +11,7 @@ variable "common_tags" {
 }
 
 variable "sns_topic_arn" {
-  description = "Optional ARN of the SNS topic to subscribe the SQS queue to. If not provided (empty string), a SNS topic will be created and S3 bucket notifications will be created to the new SNS topic."
+  description = "Optional ARN of the SNS topic to subscribe the SQQ queue to. If not provided (empty string), a SNS topic will be created and S3 bucket notifications will be created to the new SNS topic."
   type        = string
   default     = ""
 }
@@ -39,4 +39,8 @@ variable "lambda_udf_memory_size" {
   default     = 1024
 }
 
-
+variable "athena_execution_role_names" {
+  description = "Names of the IAM roles used to execute Athena queries (e.g. the MC integration role). Each role receives an inline policy granting lambda:InvokeFunction on the UDF. Required for Athena UDF invocation: for same-account Lambda calls AWS requires the caller identity-based policy to allow the action, even when a resource-based policy is present."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Problem

When Athena executes `USING EXTERNAL FUNCTION mcd_invoke_bedrock ... LAMBDA 'mcd-agent-observability-bedrock-udf'`, Athena invokes the Lambda using the **caller's IAM credentials** (the MC Athena integration role). Without an explicit grant, that role gets:

```
Insufficient permissions to execute the query.
```

## Root cause

For same-account Lambda invocations, AWS evaluates **both** the resource-based policy and the caller's identity-based policy. A resource-based policy granting `arn:aws:iam::ACCOUNT:root` is **not** sufficient alone — the calling IAM role must also have `lambda:InvokeFunction` in its own identity policy. Confirmed via Athena ErrorType 1500:

```
User: arn:aws:sts::404798114945:assumed-role/monte-carlo-integration-role-*/...
is not authorized to perform: lambda:InvokeFunction
because no identity-based policy allows the lambda:InvokeFunction action
```

## Fix

Add `aws_iam_role_policy` that attaches `lambda:InvokeFunction` on the UDF to each IAM role passed via `var.athena_execution_role_names`. Callers provide the MC integration role name(s) so the module wires the permission automatically.

```terraform
resource "aws_iam_role_policy" "athena_execution_role_udf_invoke" {
  for_each = toset(var.athena_execution_role_names)
  name     = "${var.deployment_name}-bedrock-udf-invoke"
  role     = each.value
  policy   = jsonencode({ ... lambda:InvokeFunction on UDF ARN ... })
}
```

Also removes the previous (incorrect) `aws_lambda_permission` with account-root principal and the `data.aws_caller_identity` data source it required.

## Verified on dev (2026-08-08)

After applying the equivalent inline policy to `monte-carlo-integration-role-1775168925.830164` in account `404798114945`:
- Monitor ran to `SUCCESS` in 89s with `totalResultCount=1`
- `getAgentEvaluationRunSamples` returned `status: OK` with 10+ span-scoped samples (`traceId`/`spanId` populated, `conversationId: null`)