### PR TITLE
Bump Athena Bedrock UDF base image to Python 3.12 (Amazon Linux 2023)

### DIFF
--- a/modules/athena-resources/lambda-udf/Dockerfile
+++ b/modules/athena-resources/lambda-udf/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.12
 
 # Copy requirements and install dependencies
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/


### PR DESCRIPTION
Resolves [OLYM-7666](https://linear.app/montecarloai/issue/OLYM-7666/olympus-amazon-linux) (Aikido group 25692263 — issues 210349480, 212295069, 207040492).

## What

One line: `public.ecr.aws/lambda/python:3.11` → `:3.12` in `modules/athena-resources/lambda-udf/Dockerfile`.

## Why

The `python:3.11` Lambda base image is built on Amazon Linux 2, which reached general EOL on 2026-06-30.

AWS does keep patching the 3.10/3.11 Lambda base images until 2027-06-30, so the base isn't unsupported today — but our published images are only rebuilt when this module changes, so they drift behind that patch stream. Moving to `:3.12` puts the UDF on Amazon Linux 2023 (EOL 2029-06-30) and removes AL2 from the image entirely rather than resetting a deadline.

## Why 3.12 and not 3.13

`numpy==1.26.4` and `pyarrow==15.0.2` publish no cp313 wheels, so 3.13 falls back to an sdist build that fails on the missing toolchain. 3.12 requires no dependency changes.

## Verification

`docker buildx build --no-cache --platform linux/amd64`:

```
PRETTY_NAME="Amazon Linux 2023.12.20260803"
python 3.12.13
handler OK -> BedrockClaudeUDF
numpy 1.26.4 | pyarrow 15.0.2 | boto3 1.42.13
pyarrow IPC rows: 3
```

## Follow-up — merge alone will not clear the findings

1. CI publishes only the **prod** ECR repo on `main` merge.
2. The **pre-release** and **dev us-west-2** repos have no automated publish path.
3. The two `mcd-agent-observability-bedrock-udf` functions pin `:latest`, so Terraform won't move them — each needs a forced update.
4. Rescan in Aikido to confirm the findings clear.

## Severity

Low. The UDF is invoked by Athena SQL for AO eval LLM-as-judge, there's no customer data in dev or the demo account, no customer has the Athena Lambda deployed, and no CVE is attached — this is a distro-lifecycle signal.

## Noted, not addressed here

`.circleci/config.yml`'s `/^v\d+\.\d+\.\d+.*/` filter sits under `filters.branches`, so it can never match a tag — only `main` merges publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)