### PR TITLE
Drop the Lambda Runtime Interface Emulator from the UDF image

### DIFF
--- a/modules/athena-resources/lambda-udf/Dockerfile
+++ b/modules/athena-resources/lambda-udf/Dockerfile
@@ -4,6 +4,11 @@ FROM public.ecr.aws/lambda/python:3.12
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
 RUN pip install --no-cache-dir -r requirements.txt
 
+# The Runtime Interface Emulator runs only when AWS_LAMBDA_RUNTIME_API is unset,
+# which never holds in a deployed Lambda, so it is unreachable here. Removing it
+# keeps its Go stdlib CVEs out of our scan surface.
+RUN rm -f /usr/local/bin/aws-lambda-rie
+
 # Copy handler code
 COPY handler.py ${LAMBDA_TASK_ROOT}/
 


### PR DESCRIPTION
Resolves the `golang.org/x/sys` vulnerability ticket ([OLYM-7683](https://linear.app/montecarloai/issue/OLYM-7683/olympus-golangorgxsys)) for the two Athena UDF images it names — the production and pre-release channels, both built from this Dockerfile.

## Why

Aikido flags `golang.org/x/sys` inside `/usr/local/bin/aws-lambda-rie`, the Lambda Runtime Interface Emulator that ships in the `public.ecr.aws/lambda/python` base image. The emulator only executes when `AWS_LAMBDA_RUNTIME_API` is unset:

```sh
if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
  exec /usr/local/bin/aws-lambda-rie $RUNTIME_ENTRYPOINT
else
  exec $RUNTIME_ENTRYPOINT
fi
```

That variable is always set in a deployed Lambda, so the emulator is never reachable in production. Removing it takes an unreachable binary out of the image filesystem, so it cannot be executed and stops being scanned. This is the third time RIE stdlib CVEs have come through triage on images built on this base, so it is a durable fix rather than another per-CVE disposition.

**This does not shrink the image.** The binary comes from the base image layer, so deleting it in one of our layers only writes a whiteout over it — measured 745MB both with and without the change. The benefit is reachability and scan surface, not size.

Worth noting the underlying advisory would not have been exploitable anyway: the affected symbol lives in `golang.org/x/sys/windows` and [GO-2026-5024](https://vuln.go.dev/ID/GO-2026-5024.json) scopes it `goos: ["windows"]`, while these images are Linux. The value here is retiring the recurring finding, not closing real exposure.

## Verification

Built the image locally and confirmed against it:

- `/usr/local/bin/aws-lambda-rie` is absent from our image, still present in the base image
- `handler.py` imports cleanly
- With `AWS_LAMBDA_RUNTIME_API` set, the entrypoint execs `/var/runtime/bootstrap` and reaches handler import — the deployed path is unaffected
- Image size measured identical (745MB) with and without the removal

There are no references to RIE, local `docker run` invocation, or port-9000 emulator testing anywhere in this repo, so nothing depended on it being present.

One thing I have not independently proven: that Aikido scans the flattened filesystem rather than per-layer. Given it reports the path as `usr/local/bin/aws-lambda-rie`, flattened is very likely, but if it scans layers individually the finding may persist. Worth confirming on the next scan after this merges.

## Risk

Local testing of this image via the emulator would now fail. Nothing in the repo documents or automates that workflow. If someone needs it, `docker run` with the RIE mounted in, or a build arg to retain it, would both work.

## Checklist

- [na] Terraform plan reviewed — no Terraform changes, Dockerfile only
- [x] Change verified against a built artifact
- [na] Docs updated — no documented behaviour changes
- [na] Migration/rollback considerations — image rebuild on merge; revert restores the emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
